### PR TITLE
Remove socat for better X11 performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN set -ex; \
       git \
       net-tools \
       novnc \
-      socat \
       supervisor \
       x11vnc \
       xterm \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This image is intended to be used for displaying X11 applications from other con
 * [x11vnc](http://www.karlrunge.com/x11vnc/) - A VNC server that scrapes the above X11 server
 * [noNVC](https://kanaka.github.io/noVNC/) - A HTML5 canvas vnc viewer
 * [Fluxbox](http://www.fluxbox.org/) - a small window manager
-* [socat](http://www.dest-unreach.org/socat/) - for use with other containers
 * [xterm](http://invisible-island.net/xterm/) - to demo that it works
 * [supervisord](http://supervisord.org) - to keep it all running
 

--- a/conf.d/socat.conf
+++ b/conf.d/socat.conf
@@ -1,3 +1,0 @@
-[program:socat]
-command=socat tcp-listen:6000,reuseaddr,fork unix:/tmp/.X11-unix/X0
-autorestart=true

--- a/conf.d/xvfb.conf
+++ b/conf.d/xvfb.conf
@@ -1,3 +1,3 @@
 [program:xvfb]
-command=Xvfb :0 -screen 0 "%(ENV_DISPLAY_WIDTH)s"x"%(ENV_DISPLAY_HEIGHT)s"x24
+command=Xvfb :0 -screen 0 "%(ENV_DISPLAY_WIDTH)s"x"%(ENV_DISPLAY_HEIGHT)s"x24 -listen tcp
 autorestart=true

--- a/conf.d/xvfb.conf
+++ b/conf.d/xvfb.conf
@@ -1,3 +1,3 @@
 [program:xvfb]
-command=Xvfb :0 -screen 0 "%(ENV_DISPLAY_WIDTH)s"x"%(ENV_DISPLAY_HEIGHT)s"x24 -listen tcp
+command=Xvfb :0 -screen 0 "%(ENV_DISPLAY_WIDTH)s"x"%(ENV_DISPLAY_HEIGHT)s"x24 -listen tcp -ac
 autorestart=true


### PR DESCRIPTION
**Issue** `socat` is bottleneck.
**Solution** Remove `socat` and add `-listen tcp` option to Xvfb instead.
**Benchmark** Gets approx. twice faster if socat is removed. `x11perf -display localhost:0 -all`
**My comment** It'll be greatly appreciated if you keep dockerhub updated with this nice project. :)

**W/ socat**

- Tens of millions of X11 ops per sec.
![w-socat](https://user-images.githubusercontent.com/721858/59172706-7ec08180-8b84-11e9-9408-ea85634a30b7.PNG)

**W/o socat**

- 100+ millions of X11 ops per sec.
![wo-socat](https://user-images.githubusercontent.com/721858/59172725-9bf55000-8b84-11e9-891f-14c8f373b1c3.PNG)
